### PR TITLE
Batch prompts using CSVs and an array of prompts

### DIFF
--- a/workflow/celery_task.py
+++ b/workflow/celery_task.py
@@ -204,6 +204,8 @@ def upload_datasets_to_hf(task_id, split, repo_id):
     data = []
     for example in examples:
         pairs = {}
+        pairs["example_id"] = example.example_id
+        pairs["prompt_id"] = example.prompt.id
         for key, value in example.text.items():
             pairs[key] = value
         data.append(pairs)
@@ -224,7 +226,7 @@ def upload_datasets_to_hf(task_id, split, repo_id):
 
     uploaded_at = datetime.now()
     for i, split in enumerate(splits):
-        csv_data = split.to_csv()
+        csv_data = split.to_csv(index=False)
         file_data = csv_data.encode("utf-8")
         operation = CommitOperationAdd(f"{split_name[i]}.csv", file_data)
         commit_info = hf_api.create_commit(

--- a/workflow/celery_task.py
+++ b/workflow/celery_task.py
@@ -2,26 +2,32 @@ import logging
 import re
 from datetime import datetime
 from decimal import Decimal, getcontext
+from typing import List
 
 import pandas as pd
 from celery import shared_task
 from django.conf import settings
+from gevent import joinall, spawn
 from huggingface_hub import CommitOperationAdd, HfApi
 
 from .dataFetcher import DataFetcher
-from .models import Dataset, Examples, Task, Workflows
+from .models import Dataset, Examples, Prompt, Task, Workflows
 from .utils import create_pydantic_model, get_model_cost
 
 logger = logging.getLogger(__name__)
 
-max_iterations = int(getattr(settings, "MAX_ITERATIONS", 100))
-
 
 @shared_task(bind=True, max_retries=settings.CELERY_MAX_RETRIES, retry_backoff=True)
-def process_task(self, task_id, max_iterations, max_concurrent_fetches, batch_size):
+def process_task(
+    self,
+    task_id: str,
+    max_iterations: int,
+    max_concurrent_fetches: int,
+    batch_size: int,
+    prompts: List[str],
+):
     task = Task.objects.get(id=task_id)
     workflow: Workflows = task.workflow
-
     workflow.status = "GENERATION"
     workflow.save()
     task.status = "Processing"
@@ -30,36 +36,52 @@ def process_task(self, task_id, max_iterations, max_concurrent_fetches, batch_si
 
     Model, _ = create_pydantic_model(workflow.workflow_config.schema_example)
 
-    fetcher = DataFetcher(
-        max_iterations=max_iterations,
-        max_concurrent_fetches=max_concurrent_fetches,
-        batch_size=batch_size,
-    )
-    fetcher.generate_or_refine(
-        workflow_id=workflow.workflow_id,
-        total_examples=workflow.total_examples,
-        workflow_config_id=workflow.workflow_config.id,
-        llm_model=workflow.llm_model,
-        Model=Model,
-        refine=True,
-        task_id=task_id,
-        iteration=1,
-    )
+    if len(prompts) > 0:
+        generator = GenerateMultiplePrompts(
+            workflow=workflow,
+            prompts=prompts,
+            max_iterations=max_iterations,
+            max_concurrent_fetches=max_concurrent_fetches,
+            batch_size=batch_size,
+            task=task,
+            Model=Model,
+        )
+        generator.controller()
+    else:
+        fetcher = DataFetcher(
+            max_iterations=max_iterations,
+            max_concurrent_fetches=max_concurrent_fetches,
+            batch_size=batch_size,
+        )
+        prompt: Prompt = workflow.latest_prompt
+        fetcher.generate_or_refine(
+            workflow_id=workflow.workflow_id,
+            total_examples=workflow.total_examples,
+            workflow_config_id=workflow.workflow_config.id,
+            llm_model=workflow.llm_model,
+            prompt=prompt.user_prompt,
+            prompt_id=prompt.id,
+            Model=Model,
+            refine=True,
+            task_id=task_id,
+            iteration=1,
+        )
 
-    task.refresh_from_db()
-    print(f"generated samples= {task.generated_samples} in celery")
+        task.refresh_from_db()
+        print(f"generated samples= {task.generated_samples} in celery")
 
-    costs = get_model_cost(workflow.llm_model)
+        costs = get_model_cost(workflow.llm_model)
 
-    getcontext().prec = 6
+        getcontext().prec = 6
 
-    input_cost = Decimal(fetcher.input_tokens * costs["input"]) / Decimal(1000)
-    output_cost = Decimal(fetcher.output_tokens * costs["output"]) / Decimal(1000)
+        input_cost = Decimal(fetcher.input_tokens * costs["input"]) / Decimal(1000)
+        output_cost = Decimal(fetcher.output_tokens * costs["output"]) / Decimal(1000)
 
-    iteration_cost = input_cost + output_cost
-    iteration_cost = iteration_cost.quantize(Decimal("0.0001"))
-    workflow.cost += iteration_cost
-    workflow.cost = workflow.cost.quantize(Decimal("0.0001"))
+        iteration_cost = input_cost + output_cost
+        iteration_cost = iteration_cost.quantize(Decimal("0.0001"))
+        workflow.cost += iteration_cost
+        workflow.cost = workflow.cost.quantize(Decimal("0.0001"))
+        workflow.save()
 
     workflow.status = "PUSHING_DATASET"
     workflow.save()
@@ -86,6 +108,86 @@ def process_task(self, task_id, max_iterations, max_concurrent_fetches, batch_si
     task.status = "Completed"
     task.dataset = dataset
     task.save()
+
+
+class GenerateMultiplePrompts:
+    def __init__(
+        self,
+        prompts,
+        workflow,
+        max_iterations,
+        max_concurrent_fetches,
+        batch_size,
+        task,
+        Model,
+    ):
+        self.workflow: Workflows = workflow
+        self.completed_prompts = []
+        self.pending_prompts = []
+        self.max_iterations: int = max_iterations
+        self.max_concurrent_fetches: int = max_concurrent_fetches
+        self.batch_size: int = batch_size
+        self.task: Task = task
+        self.Model = Model
+        for prompt in prompts:
+            prompt = Prompt.objects.create(workflow=workflow, user_prompt=prompt)
+            self.pending_prompts.append({"prompt": prompt.user_prompt, "id": prompt.id})
+
+    def controller(self):
+        greenlets = [
+            spawn(
+                self.request_and_save,
+                prompt["prompt"],
+                prompt["id"],
+            )
+            for prompt in [
+                self.pending_prompts.pop(0)
+                for _ in range(
+                    min(len(self.pending_prompts), self.max_concurrent_fetches)
+                )
+            ]
+        ]
+        joinall(greenlets)
+
+        if len(self.pending_prompts) > 0:
+            self.controller()
+
+    def request_and_save(self, user_prompt, prompt_id):
+        print(f"requesting for user_prompt \n{user_prompt}")
+        fetcher = DataFetcher(
+            max_iterations=self.max_iterations,
+            max_concurrent_fetches=self.max_concurrent_fetches,
+            batch_size=self.batch_size,
+        )
+
+        fetcher.generate_or_refine(
+            workflow_id=self.workflow.workflow_id,
+            total_examples=self.workflow.total_examples,
+            workflow_config_id=self.workflow.workflow_config.id,
+            llm_model=self.workflow.llm_model,
+            prompt=user_prompt,
+            prompt_id=prompt_id,
+            Model=self.Model,
+            refine=True,
+            task_id=self.task.id,
+            iteration=1,
+        )
+
+        self.task.refresh_from_db()
+        print(f"generated samples= {self.task.generated_samples} in celery")
+
+        costs = get_model_cost(self.workflow.llm_model)
+
+        getcontext().prec = 6
+
+        input_cost = Decimal(fetcher.input_tokens * costs["input"]) / Decimal(1000)
+        output_cost = Decimal(fetcher.output_tokens * costs["output"]) / Decimal(1000)
+
+        iteration_cost = input_cost + output_cost
+        iteration_cost = iteration_cost.quantize(Decimal("0.0001"))
+        self.workflow.cost += iteration_cost
+        self.workflow.cost = self.workflow.cost.quantize(Decimal("0.0001"))
+        self.workflow.save()
 
 
 def upload_datasets_to_hf(task_id, split, repo_id):


### PR DESCRIPTION
this PR adds multiple prompts in /generate using a csv file with a column named `prompts` or an array of strings in the field `prompts` of the request.

It uses gevent to concurrently generate samples for all prompts.

an additional field, `example_per_prompt` needs to be sent with multiple prompts to define the number of examples which are generated with each prompt